### PR TITLE
Updated two `euid != uid` checks with `uid_eq()`

### DIFF
--- a/kernel/cpuset.c
+++ b/kernel/cpuset.c
@@ -1429,7 +1429,7 @@ static int cpuset_allow_attach(struct cgroup *cgrp,
 		tcred = __task_cred(task);
 
 		if ((current != task) && !capable(CAP_SYS_ADMIN) &&
-		    cred->euid != tcred->uid && cred->euid != tcred->suid)
+		    !uid_eq(cred->euid, tcred->uid) && !uid_eq(cred->euid, tcred->suid))
 			return -EACCES;
 	}
 

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -9849,7 +9849,7 @@ cpu_cgroup_allow_attach(struct cgroup *cgrp, struct cgroup_taskset *tset)
 		tcred = __task_cred(task);
 
 		if ((current != task) && !capable(CAP_SYS_NICE) &&
-		    cred->euid != tcred->uid && cred->euid != tcred->suid)
+		    !uid_eq(cred->euid, tcred->uid) && !uid_eq(cred->euid, tcred->suid))
 			return -EACCES;
 	}
 


### PR DESCRIPTION
Really minor bug fix that was outputting garbage in the android compiler.
